### PR TITLE
Word Count API call

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,6 +21,12 @@ Check if an API key can be used to fetch messages from the API:
 curl -d '{"key":"your_key_here"}' -H 'Content-Type: application/json' http://localhost:3000/api/validatekey
 ```
 
+#### /api/wordcounts
+Get the most or least used words. Can be limited by passing `head`. This example returns the top 10 most used words:
+```
+curl -d '{"key":"your_key_here","head":10,"order":"asc"}' -H 'Content-Type: application/json' http://localhost:3000/api/wordcounts
+```
+
 ### Related modules
 - Functions to handle POST requests: `/libs/api/api.js`
 - Database functions: `/libs/api/apibackend.js`

--- a/libs/api/api.js
+++ b/libs/api/api.js
@@ -31,5 +31,19 @@ module.exports = {
         res.send(JSON.stringify(data))
       })
     })
+
+    webserver.app.post('/api/wordcounts', function (req, res) {
+      const key = req.body.key
+      const head = req.body.head // Top n
+      const order = req.body.order // 'asc' 'desc'
+
+      apiBackend.wordCounts(key, head, order, (error, data) => {
+        if (error) {
+          res.send(JSON.stringify({'error': error}))
+        } else {
+          res.send(JSON.stringify(data))
+        }
+      })
+    })
   }
 }

--- a/libs/api/apibackend.js
+++ b/libs/api/apibackend.js
@@ -125,5 +125,83 @@ module.exports = {
       // eslint-disable-next-line
       callback([])
     }
+  },
+
+  wordCounts: function (key, head, order, callback) {
+    var data = {}
+    var error = ''
+
+    if (head === null || isNaN(head)) {
+      head = 1000 // Show the top 1000 in whatever order was defined
+    }
+
+    if (order === null || order === undefined) {
+      order = 'desc' // Most used to least used by default
+    }
+
+    if (key !== null) {
+      // Fetch all messages
+      const query = `SELECT data, timestamp FROM message
+        JOIN chat ON message.chat_id=chat.id
+        WHERE chat_id=(SELECT id FROM chat WHERE api_key=?) AND data != ''`
+      db.conn.all(query, key, function (err, rows) {
+        if (err) {
+          error = err
+          console.log(err)
+          callback(error, [])
+          return
+        }
+
+        if (rows === undefined || !rows.length) {
+          error = 'SQLite3 query returned zero rows'
+          callback(error, [])
+          return
+        }
+
+        var wordPool = ''
+        for (var it = 0; it < rows.length; it++) {
+          // Append current message to word pool
+          wordPool += rows[it].data + ' '
+        }
+
+        // Some preparations
+        wordPool = wordPool.replace(/\n|\.|,|:|;/g, ' ')
+
+        var wordPoolArray = wordPool.split(' ')
+
+        // Merge unique words into counted pairs
+        for (var at = 0; at < wordPoolArray.length; at++) {
+          if (wordPoolArray[at]) {
+            data[wordPoolArray[at]] = (data[wordPoolArray[at]] || 0) + 1
+          }
+        }
+
+        // Convert {} to []
+        var result = Object.keys(data).map(function (key) {
+          if (key && data[key] && key !== '' && data[key] !== '') {
+            return [key, data[key]]
+          }
+        })
+
+        result.sort((a, b) => {
+          if (order === 'asc') {
+            return a[Object.keys(a)[1]] - b[Object.keys(b)[1]]
+          } else if (order === 'desc') {
+            return b[Object.keys(b)[1]] - a[Object.keys(a)[1]]
+          }
+        })
+
+        // Limit only to top N
+        var top = []
+        for (var tt = 0; tt < head; tt++) {
+          top.push(result[tt])
+        }
+
+        callback(null, top)
+      })
+    } else {
+      error = 'Missing API key'
+      callback(error, [])
+    }
   }
 }


### PR DESCRIPTION
This PR implements the **word count** API call and is related to issue #61. Milestone that's being worked towards in this case would be [Graphs and statistics page](https://github.com/PROGRADE-Tech/Tarchivebot/milestone/4).

What this call let's you do is basically get the top `{n}` most/least used words. Made for some hilarious results when I tried executing it.

### Example
#### Call
`curl -d '{"key":"KEY_HERE","head":10}' -H 'Content-Type: application/json' http://localhost:3000/api/wordcounts`
#### Returns
`[["the",5582],["to",4734],["a",4186],["I",4027],["is",3353],["that",3219],["it",3184],["and",2756],["in",2224],["shit",2177]]`

👌 

@Hoi15A Let me know if the format of the call is alright for Angular n stuff.

